### PR TITLE
[IMP] Consider unsafe fixes for UP008 as safe

### DIFF
--- a/src/{% if use_ruff %}.ruff.toml{% endif%}.jinja
+++ b/src/{% if use_ruff %}.ruff.toml{% endif%}.jinja
@@ -18,6 +18,9 @@ extend-select = [
     "{{ rule }}",
     {%- endfor %}
 ]
+{%- if odoo_version >= 11.0 %}
+extend-safe-fixes = ["UP008"]
+{%- endif %}
 exclude = ["setup/*"]
 
 [format]


### PR DESCRIPTION
### Context
- Take over this improvement: `https://github.com/OCA/odoo-module-migrator/pull/77`
- Instead of implementing in odoo-module-migrator (not always installed), do it directly with Ruff pre-commit hook
### This change
- As [this rule](https://docs.astral.sh/ruff/rules/super-call-with-parameters/) is taken into account in Ruff, simply applying its fix when with [extend-safe-fixes](https://docs.astral.sh/ruff/settings/#lint_extend-safe-fixes) 